### PR TITLE
Added the File for Mijia Lite/Youth Projector

### DIFF
--- a/conan.v2.json
+++ b/conan.v2.json
@@ -1,0 +1,172 @@
+{
+  "product": "Xiaomi Tv/Projector Tools",
+  "author": "Spocky",
+  "version": 2,
+  "releaseDate": "2019-03-24T00:00:00.000Z",
+  "customRecoveryUrl": "http://195.154.161.97/uploads/rainman_twrp_3.2.2.0.tar.gz",
+  "uninstallPackages": [
+    "com.duokan.videodaily",
+    "com.xiaomi.mitv.advertise",
+    "com.miui.systemAdSolution",
+    "com.mitv.care",
+    "com.xiaomi.tv.appupgrade",
+    "com.xiaomi.mitv.searchcenter",
+    "com.xiaomi.mitv.handbook",
+    "com.xiaomi.mitv.calendar",
+    "com.xiaomi.tweather",
+    "com.xiaomi.mitv.shop",
+    "com.xiaomi.mitv.shop.mihome",
+    "com.xiaomi.mitv.shop.tvshop",
+    "com.mi.umi",
+    "com.mi.umifrontend",
+    "com.xiaomi.devicereport",
+    "com.mitv.gallery",
+    "com.xiaomi.tv.gallery",
+    "com.xiaomi.mitv.karaoke.service",
+    "com.xiaomi.mibox.gamecenter",
+    "com.xiaomi.gamecenter.sdk.service.mibox",
+    "com.xiaomi.mibox.gamecenter",
+    "com.mitv.appstore.component.land",
+    "com.xiaomi.mitv.payment",
+    "com.xiaomi.mitv.pay",
+    "com.mipay.wallet.tv",
+    "com.miui.tv.analytics",
+    "com.xiaomi.statistic",
+    "com.xiaomi.voicecontrol",
+    "com.xm.webcontent",
+    "com.xiaomi.mimusic2",
+    "com.mitv.screensaver",
+    "com.mi.umi",
+    "com.mi.umifrontend",
+    "com.xiaomi.account.auth",
+    "com.xiaomi.account",
+    "com.xiaomi.screenrecorder",
+    "com.sohu.inputmethod.sogou.tv",
+    "com.sogou.speech.offlineservice",
+    "com.baidu.input"
+  ],
+  "installPackages": [
+    {
+      "name": "Aptoide Tv Store",
+      "url": "http://apkins.aptoide.com/AptoideTV-5.0.2.apk"
+    },
+    {
+      "name": "LeanbackIme Keyboard",
+      "url": "https://gitlab.incom.co/CM-Shield/proprietary_vendor_nvidia/raw/4be705a39b5a6f6165cf3b6cca856a817ab7886d/shield_common/proprietary/priv-app/LeanbackIme/LeanbackIme.apk"
+    },
+    {
+      "name": "ATV Launcher free 0.11",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=42776686"
+    },
+    {
+      "name": "Tv App Repo 1.1.4-Playstore",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=33931069"
+    },
+    {
+      "name": "Cetusplay 4.5.6.1",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=41913214"
+    },
+    {
+      "name": "Youtube Tv 2.02.14",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=36679679"
+    },
+    {
+      "name": "CineTrailer 4.0.46",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=42562217"
+    },
+    {
+      "name": "SPMC 16.6",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=22780729"
+    },
+    {
+      "name": "Plex 7.9.0.8414",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=42575864"
+    },
+    {
+      "name": "MyCanal 3.5.14b2",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=41541847"
+    },
+    {
+      "name": "Molotov Tv 3.3.3",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=42551435"
+    },
+    {
+      "name": "Screen Test 9.3.0.1",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=26432785"
+    },
+    {
+      "name": "MoreLocale 2.3.1",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=5536454"
+    },
+    {
+      "name": "Amlogic TV Box tool 1.0.28",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=41691341"
+    },
+    {
+      "name": "Notifications for Android Tv 4.6.0",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=44223523"
+    },
+    {
+      "name": "MiXPlorer 6.31.12",
+      "url": "http://webservices.aptoide.com/apkinstall/apk?uid=43023291"
+    },
+    {
+      "name": "Google services/apps",
+      "url": "http://195.154.161.97/uploads/gapps.06d1a76b314a762d7db6884d7196f4e2.tar.gz"
+    }
+  ],
+  "customPropsOverrides": [
+    {
+      "key": "ro.debuggable",
+      "value": "1"
+    },
+    {
+      "key": "ro.product.locale",
+      "value": "en-US"
+    },
+    {
+      "key": "ro.wifi.channels",
+      "value": "14"
+    },
+    {
+      "key": "ro.build.fingerprint",
+      "value": "MI/anglee/anglee:8.1.0/OPM5.171019.017/891:user/release-keys"
+    },
+    {
+      "key": "ro.bootimage.build.fingerprint",
+      "value": "MI/anglee/anglee:8.1.0/OPM5.171019.017/891:user/release-keys"
+    },
+    {
+      "key": "sys.set_adb_disabled",
+      "value": "false"
+    },
+    {
+      "key": "persist.sys.usb.netadb.config",
+      "value": "1"
+    },
+    {
+      "key": "persist.sys.version.type",
+      "value": "cts"
+    },
+    {
+      "key": "persist.mi.detected.country",
+      "value": "US"
+    },
+    {
+      "key": "media.amplayer.widevineenable",
+      "value": "true"
+    },
+    {
+      "key": "media.decoder.vfm.drmmap",
+      "value": "decoder amvideo"
+    },
+    {
+      "key": "ro.com.google.clientidbase",
+      "value": "android-xiaomi-tv"
+    },
+    {
+      "key": "ro.nrdp.modelgroup",
+      "value": "XIAOMIM12TRIAL"
+    }
+  ]
+}


### PR DESCRIPTION
I have created a new file with the build name of **conan**. This build name is for the Mijia Lite/Youth Projector in which the rainman twrp worked for rooting the device.

I have copied the values from the Rainman file assuming that if the twrp worked. then this is my best bet and also that other values which are default in the system also worked well for me.

Let me know if I am missing something.