### PR TITLE
Add a trailing space in the titles of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[Bug]"
+title: "[Bug] "
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Request]"
+title: "[Request] "
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
This leaves the cursor ready to type the first word of the descrpiption,
and might give less of an impression that the entire title should be
`[Bug]` or `[Request]` as some issues have done.
